### PR TITLE
Add Whitelist and OPS to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM openjdk:21-buster
 
 LABEL version="1.27.0"
 
-RUN apt-get update && apt-get install -y curl unzip && \
- adduser --uid 99 --gid 100 --home /data --disabled-password minecraft
+RUN apt-get update && apt-get install -y curl unzip jq && \
+    adduser --uid 99 --gid 100 --home /data --disabled-password minecraft
 
 COPY launch.sh /launch.sh
 RUN chmod +x /launch.sh

--- a/README.md
+++ b/README.md
@@ -33,18 +33,13 @@ As the end user, you are repsonsible for accepting the EULA from Mojang to run t
 
 ## Options
 
-These environment variables can be set at run time to override their defaults.
+These environment variables can be set to override their defaults.
 
 * JVM_OPTS "-Xms2048m -Xmx4096m"
 * MOTD "All the Mods 10-1.27.0 Server Powered by Docker"
-* LEVEL world
-
-### Adding Minecraft Operators
-
-Set the enviroment variable `OPS` with a comma separated list of players.
-
-example:
-`OPS="OpPlayer1,OpPlayer2"`
+* ENABLE_WHITELIST "true" or "false"
+* WHITELIST_USERS "TestUserName1, TestUserName2"
+* OP_USERS "TestUserName1, TestUserName2"
 
 ## Troubleshooting
 


### PR DESCRIPTION
See [XML-PR](https://github.com/W3LFARe/unraid_templates/pull/4) as well.

I hated it to always search up the UUID's from my friends. So I build it in the docker image as a variable with comma-separated entries. This will automatically look up the UUID of the Person and amend it in whitelist.json or ops.json. 

As well, I've added a Whitelist_enable parameter, which I personally think needs to be set to true per default. This will change the whitelist=false to whitelist=true in the server.properties file.

I hope this helps, making the image better ^^