### PR TITLE
fix: Added removal of neoforge jars and old server files zips when updating.

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -14,10 +14,10 @@ else
 fi
 
 if ! [[ -f "Server-Files-$SERVER_VERSION.zip" ]]; then
-    rm -fr config defaultconfigs kubejs mods packmenu Simple.zip forge*
-    curl -Lo "Server-Files-$SERVER_VERSION.zip" 'https://edge.forgecdn.net/files/6116/912/ServerFiles-2.28.zip' || exit 9
+    rm -fr config defaultconfigs kubejs mods packmenu Server-Files-* neoforge*
+    curl -Lo "Server-Files-$SERVER_VERSION.zip" "https://edge.forgecdn.net/files/6116/912/ServerFiles-$SERVER_VERSION.zip" || exit 9
     unzip -u -o "Server-Files-$SERVER_VERSION.zip" -d /data
-    DIR_TEST=$(find . -type d -maxdepth 1 | tail -1 | sed 's/^.\{2\}//g')
+    DIR_TEST="ServerFiles-$SERVER_VERSION"
     if [[ $(find . -type d -maxdepth 1 | wc -l) -gt 1 ]]; then
         cd "${DIR_TEST}"
         find . -type d -exec chmod 777 {} +

--- a/launch.sh
+++ b/launch.sh
@@ -15,7 +15,7 @@ fi
 
 if ! [[ -f "Server-Files-$SERVER_VERSION.zip" ]]; then
     rm -fr config defaultconfigs kubejs mods packmenu Server-Files-* neoforge*
-    curl -Lo "Server-Files-$SERVER_VERSION.zip" "https://edge.forgecdn.net/files/6116/912/ServerFiles-$SERVER_VERSION.zip" || exit 9
+    curl -Lo "Server-Files-$SERVER_VERSION.zip" "https://edge.forgecdn.net/files/6122/030/ServerFiles-$SERVER_VERSION.zip" || exit 9
     unzip -u -o "Server-Files-$SERVER_VERSION.zip" -d /data
     DIR_TEST="ServerFiles-$SERVER_VERSION"
     if [[ $(find . -type d -maxdepth 1 | wc -l) -gt 1 ]]; then


### PR DESCRIPTION
- Added the removal of old server files zips and neoforge jars when updating versions
- Added version number to url when downloading new server versions
- Changed the 'DIR_TEST' variable to unzipped server files folder
    - After updating existing server, the current DIR_TEST will point to the libraries folder and copy all contents onto /data, my guess is that this was intended to go into the new server files and copy the contents into `/data` and then delete the folder. However, `find . -type d -maxdepth 1 | tail -1 | sed 's/^.\{2\}//g'` gets the list of directories in `/data` and then selects the last folder which is not the server files folder when updating an existing server