### PR TITLE
Fix server download URL for AllTheMods 10 version 2.47

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM openjdk:21-buster
 
-LABEL version="2.41"
+LABEL version="2.47"
 
 RUN apt-get update && apt-get install -y curl unzip jq && \
     adduser --uid 99 --gid 100 --home /data --disabled-password minecraft

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [All the Mods 10-2.41](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10) on Curseforge
+# [All the Mods 10-2.47](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10) on Curseforge
 <!-- toc -->
 
 - [Description](#description)
@@ -17,7 +17,7 @@
 
 This container is built to run on an [Unraid](https://unraid.net) server, outside of that your mileage will vary.
 
-The docker on the first run will download the same version as tagged `All the Mods 10-2.39` and install it.  This can take a while as the Forge installer can take a bit to complete.  You can watch the logs and it will eventually finish.
+The docker on the first run will download the same version as tagged `All the Mods 10-2.47` and install it.  This can take a while as the Forge installer can take a bit to complete.  You can watch the logs and it will eventually finish.
 
 After the first run, it will simply start the server.
 
@@ -36,7 +36,7 @@ As the end user, you are responsible for accepting the EULA from Mojang to run t
 These environment variables can be set to override their defaults.
 
 * JVM_OPTS "-Xms2048m -Xmx4096m"
-* MOTD "All the Mods 10-2.39 Server Powered by Docker"
+* MOTD "All the Mods 10-2.47 Server Powered by Docker"
 * ALLOW_FLIGHT "true" or "false"
 * MAX_PLAYERS "5"
 * ONLINE_MODE "true" or "false"

--- a/launch.sh
+++ b/launch.sh
@@ -15,7 +15,7 @@ fi
 
 if ! [[ -f "Server-Files-$SERVER_VERSION.zip" ]]; then
     rm -fr config defaultconfigs kubejs mods packmenu Server-Files-* neoforge*
-    curl -Lo "Server-Files-$SERVER_VERSION.zip" "https://edge.forgecdn.net/files/6313/714/ServerFiles-$SERVER_VERSION.zip" || exit 9
+    curl -Lo "Server-Files-$SERVER_VERSION.zip" "https://mediafilez.forgecdn.net/files/6502/782/ServerFiles-$SERVER_VERSION.zip" || exit 9
     unzip -u -o "Server-Files-$SERVER_VERSION.zip" -d /data
     DIR_TEST="ServerFiles-$SERVER_VERSION"
     if [[ $(find . -type d -maxdepth 1 | wc -l) -gt 1 ]]; then

--- a/launch.sh
+++ b/launch.sh
@@ -2,8 +2,8 @@
 
 set -x
 
-NEOFORGE_VERSION=21.1.133
-SERVER_VERSION=2.41
+NEOFORGE_VERSION=21.1.168
+SERVER_VERSION=2.47
 cd /data
 
 if ! [[ "$EULA" = "false" ]]; then


### PR DESCRIPTION
This PR updates the server files download URL to correctly fetch AllTheMods 10 version 2.47.

Changes:
- Updated the download URL to: mediafilez.forgecdn.net/files/6502/782/ServerFiles-2.47.zip
- Fixed line endings in launch.sh for proper execution in container environment
